### PR TITLE
Removed openconnect VPN protocol special handling

### DIFF
--- a/af_ktls.h
+++ b/af_ktls.h
@@ -50,11 +50,6 @@
 #define KTLS_GET_MTU			17
 
 /*
- * Additional options
- */
-#define KTLS_PROTO_OPENCONNECT		128
-
-/*
  * Supported ciphers
  */
 #define KTLS_CIPHER_AES_GCM_128		51


### PR DESCRIPTION
That special case should be handled using a more generic
method that can accomodate more protocols defined by userspace.